### PR TITLE
fix: ignore commits in other ws dir with same prefix

### DIFF
--- a/packages/filter-by-workspace-path/src/index.ts
+++ b/packages/filter-by-workspace-path/src/index.ts
@@ -6,10 +6,11 @@ import * as path from 'path'
 function shouldOmitCommit(currentDir: string, currentWorkspace: string, commit: IExtendedCommit, logger: ILogger): boolean {
   // auto adds the current path to the file paths reported from git, so we need to undo this
   const fixedFiles = commit.files.map((file) => path.relative(currentDir, file))
+  const wsDir = path.join(currentWorkspace, path.sep)
 
-  const atLeastOneFileInCurrentDir = fixedFiles.find((file) => file.startsWith(currentWorkspace))
+  const atLeastOneFileInCurrentDir = fixedFiles.find((file) => file.startsWith(wsDir))
   if (!atLeastOneFileInCurrentDir) {
-    logger.verbose.log(`All files are outside the current workspace directory ('${currentWorkspace}'). Omitting commit '${commit.hash}'.`)
+    logger.verbose.log(`All files are outside the current workspace directory ('${wsDir}'). Omitting commit '${commit.hash}'.`)
     return true
   } else {
     if (commit.labels?.includes('skip-release') || commit.subject?.includes('[skip ci]')) {
@@ -17,7 +18,7 @@ function shouldOmitCommit(currentDir: string, currentWorkspace: string, commit: 
       return true
     }
 
-    logger.verbose.log(`At least one file is in the current workspace ('${currentWorkspace}'). Including commit '${commit.hash}'.`)
+    logger.verbose.log(`At least one file is in the current workspace ('${wsDir}'). Including commit '${commit.hash}'.`)
     return false
   }
 }

--- a/packages/filter-by-workspace-path/test/index.spec.ts
+++ b/packages/filter-by-workspace-path/test/index.spec.ts
@@ -24,31 +24,31 @@ const setup = () => {
 }
 
 describe('Omit Commits Plugin', () => {
-  test('should not filter the commit single file', async () => {
+  it('should not filter the commit single file', async () => {
     const hooks = setup()
     const commit = makeCommitFromMsg('foo', { files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts')] })
     expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
   })
 
-  test('should filter the commit single file', async () => {
+  it('should filter the commit single file', async () => {
     const hooks = setup()
     const commit = makeCommitFromMsg('foo', { files: ['/outside'] })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
-  test('should not filter the commit multi file', async () => {
+  it('should not filter the commit multi file', async () => {
     const hooks = setup()
     const commit = makeCommitFromMsg('foo', { files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts'), '/outside'] })
     expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
   })
 
-  test('should filter the commit single file', async () => {
+  it('should filter the commit single file', async () => {
     const hooks = setup()
     const commit = makeCommitFromMsg('foo', { files: ['/outside', '/anotheroutsider'] })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
-  test('should skip commit labeled as skip-release', async () => {
+  it('should skip commit labeled as skip-release', async () => {
     const hooks = setup()
     const commit = makeCommitFromMsg('foo', {
       labels: ['skip-release'],
@@ -57,11 +57,17 @@ describe('Omit Commits Plugin', () => {
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
-  test('should skip commit marked as skip-ci', async () => {
+  it('should skip commit marked as skip-ci', async () => {
     const hooks = setup()
     const commit = makeCommitFromMsg('foo [skip ci]', {
       files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts')],
     })
+    expect(await hooks.omitCommit.promise(commit)).toBe(true)
+  })
+
+  fit('should skip commit in a sub-directory with the same prefix', async () => {
+    const hooks = setup()
+    const commit = makeCommitFromMsg('foo', { files: [path.resolve('.', 'packages/filter-by-workspace-path-sub-dir/src/index.ts')] })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes a bug where changes in a different workspace with the same prefix were not filtered out correctly.

*Example*:
- `my-ws`
- `my-ws-two`

If there were changes only in `my-ws` and you run the filter on `my-ws-two`, it should filter out all commits. But actually, before this fix, it would include commits against `my-ws` because of a missing path separator at the end of the workspace name.