### PR TITLE
doc: note about skip-release label

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,13 @@
       "name": "Auto changelog",
       "type": "node",
       "request": "launch",
-      "cwd": "${workspaceFolder}/packages/filter-by-workspace-path",
+      "cwd": "${workspaceFolder}/packages/example-test-package",
       "program": "${workspaceFolder}/node_modules/auto/dist/bin/auto",
       "args": [
         "changelog",
         "-d",
-        "-v"
+        "--from",
+        "@restfulhead/npm-auto-plugin-example-test-package_v0.0.2"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "sourceMaps": true,

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ A collection of plugins for [Intuit's auto package](https://github.com/intuit/au
 2. Periodically merge changes from the `main` branch into your feature branch
 3. When ready, create a pull request and label it with an appropriate release label such as `release-patch`.
 4. After code review, merge your pull request into the `main` branch.
-5. When ready to release, create a pull request from `main` to `release` (label it with `release-internal`)
+5. When ready to release, create a pull request from `main` to `release`. *Important*: Label this PR with `skip-release`.
 6. When the PR is merged, packages with changes will be automatically released.


### PR DESCRIPTION
That's because the merge commit might contain files from prior commits to the release branch. Without this label, these files would be considered as changes to be released (again).