### PR TITLE
fix: missing version in changelog file

### DIFF
--- a/packages/filter-by-workspace-path/CHANGELOG.md
+++ b/packages/filter-by-workspace-path/CHANGELOG.md
@@ -1,18 +1,12 @@
-# (Tue Feb 13 2024)
-
-
-
----
-
-# (Tue Feb 13 2024)
+# v0.1.0 (Fri Feb 16 2024)
 
 #### 🚀 Enhancement
 
-- chore: fix release [#30](https://github.com/restfulhead/npm-auto-plugins/pull/30) ([@restfulhead](https://github.com/restfulhead))
+- feat: omit commits that aren't related to a pull request [#9](https://github.com/restfulhead/npm-auto-plugins/pull/9) ([@restfulhead](https://github.com/restfulhead))
 
-#### 🔩 Internal
+#### 📝 Documentation
 
-- chore: prepare release [#32](https://github.com/restfulhead/npm-auto-plugins/pull/32) ([@restfulhead](https://github.com/restfulhead))
+- doc: provide more details about the merge commit issue [#8](https://github.com/restfulhead/npm-auto-plugins/pull/8) ([@restfulhead](https://github.com/restfulhead))
 
 #### Authors: 1
 
@@ -20,23 +14,28 @@
 
 ---
 
-# (Mon Feb 12 2024)
-
-#### 🚀 Enhancement
-
-- fix: workflow and release [#25](https://github.com/restfulhead/npm-auto-plugins/pull/25) ([@restfulhead](https://github.com/restfulhead))
-- fix: cleanup [#23](https://github.com/restfulhead/npm-auto-plugins/pull/23) ([@restfulhead](https://github.com/restfulhead))
+# v0.0.1 (Fri Feb 16 2024)
 
 #### 🐛 Patch
 
-- fix: test and release workflow [#28](https://github.com/restfulhead/npm-auto-plugins/pull/28) ([@restfulhead](https://github.com/restfulhead))
-- fix: hooks [#21](https://github.com/restfulhead/npm-auto-plugins/pull/21) ([@restfulhead](https://github.com/restfulhead))
+- fix: filter out commits in other ws dir with the same prefix [#5](https://github.com/restfulhead/npm-auto-plugins/pull/5) ([@restfulhead](https://github.com/restfulhead))
 
 #### 🔩 Internal
 
-- chore: prepare release [#29](https://github.com/restfulhead/npm-auto-plugins/pull/29) ([@restfulhead](https://github.com/restfulhead))
-- chore: prepare release [#27](https://github.com/restfulhead/npm-auto-plugins/pull/27) ([@restfulhead](https://github.com/restfulhead))
-- chore: prepare release [#24](https://github.com/restfulhead/npm-auto-plugins/pull/24) ([@restfulhead](https://github.com/restfulhead))
+- chore: prepare release [#6](https://github.com/restfulhead/npm-auto-plugins/pull/6) ([@restfulhead](https://github.com/restfulhead))
+
+#### Authors: 1
+
+- Patrick Ruhkopf ([@restfulhead](https://github.com/restfulhead))
+
+---
+
+# v0.0.1 (Tue Feb 13 2024)
+
+#### 🔩 Internal
+
+- chore: prepare release [#4](https://github.com/restfulhead/npm-auto-plugins/pull/4) ([@restfulhead](https://github.com/restfulhead))
+- refactor: renamed to follow auto's naming convention [#3](https://github.com/restfulhead/npm-auto-plugins/pull/3) ([@restfulhead](https://github.com/restfulhead))
 
 #### Authors: 1
 

--- a/packages/filter-by-workspace-path/README.md
+++ b/packages/filter-by-workspace-path/README.md
@@ -30,7 +30,6 @@ However, carefully read the following caveats section.
   * have `[skip ci]` in their commit message
 * This plugin modifies the behavior of `auto version`. By default, it seems to set the version to `patch` instead of `noVersion` even if all 
   commits were omitted. With this plugin, `noVersion` is returned if there are no relevant commits.
-* While the title in the GitHub release notes is correct, the version is missing in the `CHANGELOG.md` file for currently unknown reasons
 * You can't use the `shipit` command, because for example, the version in each package should only contain the version number 
   (e.g. `v1.0.0`), but the tag and Github release must include the package name to avoid ambigious release names/tags. Maybe this 
   customization can be added to the plugin in future. (Contributions welcome!)


### PR DESCRIPTION
Tags in our mono-repo include the package name, and the out of the box `calcNextVersion` doesn't support this.