### PR TITLE
feature: add `npm` option to allow usage of 'filter-by-workspace-path-plugin' without npm

### DIFF
--- a/packages/filter-by-workspace-path/README.md
+++ b/packages/filter-by-workspace-path/README.md
@@ -11,7 +11,7 @@ To start using this plugin, add it to your `.autorc` config, for example:
 ```json
 {
   "plugins": [
-    ["@restfulhead/auto-plugin-filter-by-workspace-path",{"non_npm":false}],
+    ["@restfulhead/auto-plugin-filter-by-workspace-path",{"npm":true}],
     "npm",
   ]
 }
@@ -20,9 +20,14 @@ To start using this plugin, add it to your `.autorc` config, for example:
 Then, if your project uses NPM workspaces and you run e.g. `auto changelog` not from the root directory, but directly from a workspace
 directory, then the changelog will only include pull requests that contain files inside the current workspace directory.
 
-If you're using auto without NPM you can specify `"non_npm": true` in the configuration, this way the plugin will filter out changes outside of the current folder `auto` is run from.
-
 However, carefully read the following caveats section.
+
+## Supported Config
+
+| Parameter               | Description                                                | Default  |
+| ----------------------- | ---------------------------------------------------------- | -------- |
+| `npm`       | Boolean to use NPM workspaces or not. In case you're using auto without NPM, specify `"npm": false`, this way the plugin will filter out changes outside of the current folder `auto` is run from. | `true`   |
+
 
 ## Caveats
 

--- a/packages/filter-by-workspace-path/README.md
+++ b/packages/filter-by-workspace-path/README.md
@@ -11,7 +11,7 @@ To start using this plugin, add it to your `.autorc` config, for example:
 ```json
 {
   "plugins": [
-    "@restfulhead/auto-plugin-filter-by-workspace-path",
+    ["@restfulhead/auto-plugin-filter-by-workspace-path",{"non_npm":false}],
     "npm",
   ]
 }
@@ -19,6 +19,8 @@ To start using this plugin, add it to your `.autorc` config, for example:
 
 Then, if your project uses NPM workspaces and you run e.g. `auto changelog` not from the root directory, but directly from a workspace
 directory, then the changelog will only include pull requests that contain files inside the current workspace directory.
+
+If you're using auto without NPM you can specify `"non_npm": true` in the configuration, this way the plugin will filter out changes outside of the current folder `auto` is run from.
 
 However, carefully read the following caveats section.
 

--- a/packages/filter-by-workspace-path/src/index.ts
+++ b/packages/filter-by-workspace-path/src/index.ts
@@ -28,34 +28,32 @@ function shouldOmitCommit(currentDir: string, currentWorkspace: string, commit: 
   }
 }
 
-export type ProjectFilteringPluginOptions ={
+export interface ProjectFilteringPluginOptions {
   /** Path from the repo root to project we are filtering on */
-  npm: boolean,
-};
+  npm: boolean
+}
 
 export default class FilterByWorkspacePathPlugin implements IPlugin {
   /** The name of the plugin */
   name = 'filter-by-workspace-path-plugin'
 
-/** The options of the plugin */
-  readonly options: ProjectFilteringPluginOptions;
+  /** The options of the plugin */
+  readonly options: ProjectFilteringPluginOptions
 
   /** Initialize the plugin with it's options */
-  constructor(options: ProjectFilteringPluginOptions = {"npm":true}) {
+  constructor(options: ProjectFilteringPluginOptions = { npm: true }) {
     this.options = options
   }
 
-
   apply(auto: Auto): void {
-
     const currentDir = path.resolve('.')
     let currentWorkspace = currentDir
 
-    if (this.options.npm){
-        const npmResult = execSync('npm ls --omit=dev --depth 1 -json', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] })
-        const workspaceDeps: any = JSON.parse(npmResult).dependencies
-        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-        currentWorkspace = workspaceDeps[Object.keys(workspaceDeps)[0] as any].resolved.substring(11)
+    if (this.options.npm) {
+      const npmResult = execSync('npm ls --omit=dev --depth 1 -json', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] })
+      const workspaceDeps: any = JSON.parse(npmResult).dependencies
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      currentWorkspace = workspaceDeps[Object.keys(workspaceDeps)[0] as any].resolved.substring(11)
     }
 
     auto.hooks.onCreateLogParse.tap(this.name, (logParse) => {

--- a/packages/filter-by-workspace-path/src/index.ts
+++ b/packages/filter-by-workspace-path/src/index.ts
@@ -10,7 +10,6 @@ function shouldOmitCommit(currentDir: string, currentWorkspace: string, commit: 
 
   // auto adds the current path to the file paths reported from git, so we need to undo this
   const fixedFiles = commit.files.map((file) => path.relative(currentDir, file))
-  console.log(fixedFiles)
   const wsDir = path.join(currentWorkspace, path.sep)
 
   const atLeastOneFileInCurrentDir = fixedFiles.find((file) => inFolder(wsDir, file))

--- a/packages/filter-by-workspace-path/src/index.ts
+++ b/packages/filter-by-workspace-path/src/index.ts
@@ -30,7 +30,7 @@ function shouldOmitCommit(currentDir: string, currentWorkspace: string, commit: 
 
 export type ProjectFilteringPluginOptions ={
   /** Path from the repo root to project we are filtering on */
-  non_npm: boolean,
+  npm: boolean,
 };
 
 export default class FilterByWorkspacePathPlugin implements IPlugin {
@@ -41,7 +41,7 @@ export default class FilterByWorkspacePathPlugin implements IPlugin {
   readonly options: ProjectFilteringPluginOptions;
 
   /** Initialize the plugin with it's options */
-  constructor(options: ProjectFilteringPluginOptions) {
+  constructor(options: ProjectFilteringPluginOptions = {"npm":true}) {
     this.options = options
   }
 
@@ -51,7 +51,7 @@ export default class FilterByWorkspacePathPlugin implements IPlugin {
     const currentDir = path.resolve('.')
     let currentWorkspace = currentDir
 
-    if (!this.options.non_npm){
+    if (this.options.npm){
         const npmResult = execSync('npm ls --omit=dev --depth 1 -json', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] })
         const workspaceDeps: any = JSON.parse(npmResult).dependencies
         // eslint-disable-next-line @typescript-eslint/no-magic-numbers

--- a/packages/filter-by-workspace-path/test/index.spec.ts
+++ b/packages/filter-by-workspace-path/test/index.spec.ts
@@ -8,7 +8,7 @@ import Release from '@auto-it/core/dist/release'
 import FilterByPathPlugin from '../src'
 
 const setup = () => {
-  const plugin = new FilterByPathPlugin({"non_npm":false})
+  const plugin = new FilterByPathPlugin()
   const hooks = makeHooks()
   const logger = createLog()
   const logParseHooks = makeLogParseHooks()

--- a/packages/filter-by-workspace-path/test/index.spec.ts
+++ b/packages/filter-by-workspace-path/test/index.spec.ts
@@ -8,7 +8,7 @@ import Release from '@auto-it/core/dist/release'
 import FilterByPathPlugin from '../src'
 
 const setup = () => {
-  const plugin = new FilterByPathPlugin()
+  const plugin = new FilterByPathPlugin({"non_npm":false})
   const hooks = makeHooks()
   const logger = createLog()
   const logParseHooks = makeLogParseHooks()


### PR DESCRIPTION
Fixes https://github.com/restfulhead/npm-auto-plugins/issues/16

Added "non_npm" usage for the plugin (updated doc too).