### PR TITLE
Fixed and improved tests for non-npm usage

### DIFF
--- a/packages/filter-by-workspace-path/src/index.ts
+++ b/packages/filter-by-workspace-path/src/index.ts
@@ -10,7 +10,7 @@ function shouldOmitCommit(currentWorkspace: string, commit: IExtendedCommit, log
 
   const wsDir = path.join(currentWorkspace, path.sep)
 
-  const atLeastOneFileInCurrentDir =  commit.files.find((file) => inFolder(wsDir, file))
+  const atLeastOneFileInCurrentDir = commit.files.find((file) => inFolder(wsDir, file))
 
   if (!atLeastOneFileInCurrentDir) {
     logger.verbose.log(`All files are outside the current workspace directory ('${wsDir}'). Omitting commit '${commit.hash}'.`)
@@ -21,7 +21,9 @@ function shouldOmitCommit(currentWorkspace: string, commit: IExtendedCommit, log
       return true
     }
 
-    logger.verbose.log(`At least one file is in the current workspace ('${atLeastOneFileInCurrentDir}' in '${wsDir}'). Including commit '${commit.hash}'.`)
+    logger.verbose.log(
+      `At least one file is in the current workspace ('${atLeastOneFileInCurrentDir}' in '${wsDir}'). Including commit '${commit.hash}'.`
+    )
     return false
   }
 }
@@ -51,16 +53,15 @@ export default class FilterByWorkspacePathPlugin implements IPlugin {
       const npmResult = execSync('npm ls --omit=dev --depth 1 -json', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] })
       const workspaceDeps: any = JSON.parse(npmResult).dependencies
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-      const resolved= workspaceDeps[Object.keys(workspaceDeps)[0] as any].resolved
-      // resolved looks like 'file:../../packages/filter-by-workspace-path'
-      const npm_relative_workspace_path = String(resolved).split(":",2)[1]
-      currentWorkspace = path.resolve(currentDir,npm_relative_workspace_path)
+      const resolved = workspaceDeps[Object.keys(workspaceDeps)[0] as any].resolved
+      // 'resolved' var looks like 'file:../../packages/filter-by-workspace-path'
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      const relativeWorkspacePath = String(resolved).split(':', 2)[1]
+      currentWorkspace = path.resolve(currentDir, relativeWorkspacePath)
     }
 
     auto.hooks.onCreateLogParse.tap(this.name, (logParse) => {
-      logParse.hooks.omitCommit.tap(this.name, (commit) =>
-        shouldOmitCommit(currentWorkspace, commit, auto.logger) ? true : undefined
-      )
+      logParse.hooks.omitCommit.tap(this.name, (commit) => (shouldOmitCommit(currentWorkspace, commit, auto.logger) ? true : undefined))
     })
 
     auto.hooks.onCreateRelease.tap(this.name, (release) => {

--- a/packages/filter-by-workspace-path/src/index.ts
+++ b/packages/filter-by-workspace-path/src/index.ts
@@ -3,16 +3,14 @@ import * as path from 'path'
 import { Auto, IExtendedCommit, ILogger, IPlugin, SEMVER, inFolder } from '@auto-it/core'
 import { inc, ReleaseType } from 'semver'
 
-function shouldOmitCommit(currentDir: string, currentWorkspace: string, commit: IExtendedCommit, logger: ILogger): boolean {
+function shouldOmitCommit(currentWorkspace: string, commit: IExtendedCommit, logger: ILogger): boolean {
   if (!commit.pullRequest) {
     return true
   }
 
-  // auto adds the current path to the file paths reported from git, so we need to undo this
-  const fixedFiles = commit.files.map((file) => path.relative(currentDir, file))
   const wsDir = path.join(currentWorkspace, path.sep)
 
-  const atLeastOneFileInCurrentDir = fixedFiles.find((file) => inFolder(wsDir, file))
+  const atLeastOneFileInCurrentDir =  commit.files.find((file) => inFolder(wsDir, file))
 
   if (!atLeastOneFileInCurrentDir) {
     logger.verbose.log(`All files are outside the current workspace directory ('${wsDir}'). Omitting commit '${commit.hash}'.`)
@@ -23,7 +21,7 @@ function shouldOmitCommit(currentDir: string, currentWorkspace: string, commit: 
       return true
     }
 
-    logger.verbose.log(`At least one file is in the current workspace ('${wsDir}'). Including commit '${commit.hash}'.`)
+    logger.verbose.log(`At least one file is in the current workspace ('${atLeastOneFileInCurrentDir}' in '${wsDir}'). Including commit '${commit.hash}'.`)
     return false
   }
 }
@@ -53,12 +51,15 @@ export default class FilterByWorkspacePathPlugin implements IPlugin {
       const npmResult = execSync('npm ls --omit=dev --depth 1 -json', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] })
       const workspaceDeps: any = JSON.parse(npmResult).dependencies
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-      currentWorkspace = workspaceDeps[Object.keys(workspaceDeps)[0] as any].resolved.substring(11)
+      const resolved= workspaceDeps[Object.keys(workspaceDeps)[0] as any].resolved
+      // resolved looks like 'file:../../packages/filter-by-workspace-path'
+      const npm_relative_workspace_path = String(resolved).split(":",2)[1]
+      currentWorkspace = path.resolve(currentDir,npm_relative_workspace_path)
     }
 
     auto.hooks.onCreateLogParse.tap(this.name, (logParse) => {
       logParse.hooks.omitCommit.tap(this.name, (commit) =>
-        shouldOmitCommit(currentDir, currentWorkspace, commit, auto.logger) ? true : undefined
+        shouldOmitCommit(currentWorkspace, commit, auto.logger) ? true : undefined
       )
     })
 

--- a/packages/filter-by-workspace-path/test/index.spec.ts
+++ b/packages/filter-by-workspace-path/test/index.spec.ts
@@ -5,10 +5,11 @@ import LogParse from '@auto-it/core/dist/log-parse'
 import { makeHooks, makeLogParseHooks, makeReleaseHooks } from '@auto-it/core/dist/utils/make-hooks'
 import createLog from '@auto-it/core/dist/utils/logger'
 import Release from '@auto-it/core/dist/release'
-import FilterByPathPlugin from '../src'
+import FilterByWorkspacePathPlugin from '../src'
+import { ProjectFilteringPluginOptions } from '../src'
 
-const setup = () => {
-  const plugin = new FilterByPathPlugin()
+const setup = (plugin_options: ProjectFilteringPluginOptions) => {
+  const plugin = new FilterByWorkspacePathPlugin(plugin_options)
   const hooks = makeHooks()
   const logger = createLog()
   const logParseHooks = makeLogParseHooks()
@@ -24,69 +25,141 @@ const setup = () => {
   return logParseHooks
 }
 
-describe('Omit Commits Plugin', () => {
+describe('Test plugin omits commits when using NPM', () => {
+  const hooks = setup({"npm":true})
+
   it('should not filter the commit single file', async () => {
-    const hooks = setup()
     const commit = makeCommitFromMsg('foo', {
       pullRequest: { number: 1 },
-      files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts')],
+      files: [path.resolve('.', 'src/index.ts')],
     })
     expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
   })
 
   it('should filter the commit single file', async () => {
-    const hooks = setup()
     const commit = makeCommitFromMsg('foo', { pullRequest: { number: 1 }, files: ['/outside'] })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
   it('should not filter the commit multi file', async () => {
-    const hooks = setup()
     const commit = makeCommitFromMsg('foo', {
       pullRequest: { number: 1 },
-      files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts'), '/outside'],
+      files: [path.resolve('.', 'src/index.ts'), '/outside'],
     })
     expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
   })
 
   it('should filter the commit single file', async () => {
-    const hooks = setup()
     const commit = makeCommitFromMsg('foo', { pullRequest: { number: 1 }, files: ['/outside', '/anotheroutsider'] })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
   it('should skip commit labeled as skip-release', async () => {
-    const hooks = setup()
     const commit = makeCommitFromMsg('foo', {
       labels: ['skip-release'],
       pullRequest: { number: 1 },
-      files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts')],
+      files: [path.resolve('.', 'src/index.ts')],
     })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
   it('should skip commit marked as skip-ci', async () => {
-    const hooks = setup()
     const commit = makeCommitFromMsg('foo [skip ci]', {
       pullRequest: { number: 1 },
-      files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts')],
+      files: [path.resolve('.', 'src/index.ts')],
     })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
-  it('should skip commit in a sub-directory with the same prefix', async () => {
-    const hooks = setup()
+  it('should not skip commit in a sub-directory with the same prefix', async () => {
     const commit = makeCommitFromMsg('foo', {
       pullRequest: { number: 1 },
-      files: [path.resolve('.', 'packages/filter-by-workspace-path-sub-dir/src/index.ts')],
+      files: [path.resolve('.', 'sub-dir/src/index.ts')],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
+  })
+
+  it('should skip commit in a sub-directory without same prefix', async () => {
+    const commit = makeCommitFromMsg('foo', {
+      pullRequest: { number: 1 },
+      files: [path.resolve('..', 'sub-dir/src/index.ts')],
     })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })
 
   it('should skip commits without related pull request', async () => {
-    const hooks = setup()
     const commit = makeCommitFromMsg('foo', {
-      files: [path.resolve('.', 'packages/filter-by-workspace-path/src/index.ts')],
+      files: [path.resolve('.', 'src/index.ts')],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBe(true)
+  })
+})
+
+describe('Test plugin omits commits without NPM', () => {
+  const hooks = setup({"npm":false})
+
+  it('should not filter the commit single file', async () => {
+    const commit = makeCommitFromMsg('foo', {
+      pullRequest: { number: 1 },
+      files: [path.resolve('.', 'src/index.ts')],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
+  })
+
+  it('should filter the commit single file', async () => {
+    const commit = makeCommitFromMsg('foo', { pullRequest: { number: 1 }, files: ['/outside'] })
+    expect(await hooks.omitCommit.promise(commit)).toBe(true)
+  })
+
+  it('should not filter the commit multi file', async () => {
+    const commit = makeCommitFromMsg('foo', {
+      pullRequest: { number: 1 },
+      files: [path.resolve('.', 'src/index.ts'), '/outside'],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
+  })
+
+  it('should filter the commit single file', async () => {
+    const commit = makeCommitFromMsg('foo', { pullRequest: { number: 1 }, files: ['/outside', '/anotheroutsider'] })
+    expect(await hooks.omitCommit.promise(commit)).toBe(true)
+  })
+
+  it('should skip commit labeled as skip-release', async () => {
+    const commit = makeCommitFromMsg('foo', {
+      labels: ['skip-release'],
+      pullRequest: { number: 1 },
+      files: [path.resolve('.', 'src/index.ts')],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBe(true)
+  })
+
+  it('should skip commit marked as skip-ci', async () => {
+    const commit = makeCommitFromMsg('foo [skip ci]', {
+      pullRequest: { number: 1 },
+      files: [path.resolve('.', 'src/index.ts')],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBe(true)
+  })
+
+  it('should not skip commit in a sub-directory with the same prefix', async () => {
+    const commit = makeCommitFromMsg('foo', {
+      pullRequest: { number: 1 },
+      files: [path.resolve('.', 'sub-dir/src/index.ts')],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBeUndefined()
+  })
+
+  it('should skip commit in a sub-directory without same prefix', async () => {
+    const commit = makeCommitFromMsg('foo', {
+      pullRequest: { number: 1 },
+      files: [path.resolve('..', 'sub-dir/src/index.ts')],
+    })
+    expect(await hooks.omitCommit.promise(commit)).toBe(true)
+  })
+
+  it('should skip commits without related pull request', async () => {
+    const commit = makeCommitFromMsg('foo', {
+      files: [path.resolve('.', 'src/index.ts')],
     })
     expect(await hooks.omitCommit.promise(commit)).toBe(true)
   })

--- a/packages/filter-by-workspace-path/test/index.spec.ts
+++ b/packages/filter-by-workspace-path/test/index.spec.ts
@@ -5,11 +5,10 @@ import LogParse from '@auto-it/core/dist/log-parse'
 import { makeHooks, makeLogParseHooks, makeReleaseHooks } from '@auto-it/core/dist/utils/make-hooks'
 import createLog from '@auto-it/core/dist/utils/logger'
 import Release from '@auto-it/core/dist/release'
-import FilterByWorkspacePathPlugin from '../src'
-import { ProjectFilteringPluginOptions } from '../src'
+import FilterByWorkspacePathPlugin, { ProjectFilteringPluginOptions } from '../src'
 
-const setup = (plugin_options: ProjectFilteringPluginOptions) => {
-  const plugin = new FilterByWorkspacePathPlugin(plugin_options)
+const setup = (pluginOptions: ProjectFilteringPluginOptions) => {
+  const plugin = new FilterByWorkspacePathPlugin(pluginOptions)
   const hooks = makeHooks()
   const logger = createLog()
   const logParseHooks = makeLogParseHooks()
@@ -26,7 +25,7 @@ const setup = (plugin_options: ProjectFilteringPluginOptions) => {
 }
 
 describe('Test plugin omits commits when using NPM', () => {
-  const hooks = setup({"npm":true})
+  const hooks = setup({ npm: true })
 
   it('should not filter the commit single file', async () => {
     const commit = makeCommitFromMsg('foo', {
@@ -96,7 +95,7 @@ describe('Test plugin omits commits when using NPM', () => {
 })
 
 describe('Test plugin omits commits without NPM', () => {
-  const hooks = setup({"npm":false})
+  const hooks = setup({ npm: false })
 
   it('should not filter the commit single file', async () => {
     const commit = makeCommitFromMsg('foo', {


### PR DESCRIPTION
Following changes: 

1. File path used in fake commits for tests were from the wrong directory, fixed that.

2. `currentWorkspace` definition wasn't generic and would fail for other project file structure, see the `substring(11)` in
 https://github.com/restfulhead/npm-auto-plugins/blob/b509925edaf0f4a8ffa18f9903213794bebf30d9/packages/filter-by-workspace-path/src/index.ts#L56

3. Also removed:
```
  // auto adds the current path to the file paths reported from git, so we need to undo this
  const fixedFiles = commit.files.map((file) => path.relative(currentDir, file))
```
 as I couldn't see this behaviour when testing, instead I think the reason for this codepath was the mistake in 1.
 
 4. Duplicated the test batteries for `non-npm` usage.